### PR TITLE
cd-ls

### DIFF
--- a/CLI/src/main/java/ru/spbau/sd/cli/interpreter/Parser.java
+++ b/CLI/src/main/java/ru/spbau/sd/cli/interpreter/Parser.java
@@ -32,9 +32,13 @@ public class Parser {
             case "exit":
                 return new CmdExit();
             case "pwd":
-                return new CmdPwd();
+                return new CmdPwd(environment);
             case "wc":
                 return new CmdWc();
+            case "ls":
+                return new CmdLs(environment);
+            case "cd":
+                return new CmdCd(environment);
             default:
                 return new ExternalCommand(cmd);
         }

--- a/CLI/src/main/java/ru/spbau/sd/cli/interpreter/SimpleEnvironment.java
+++ b/CLI/src/main/java/ru/spbau/sd/cli/interpreter/SimpleEnvironment.java
@@ -11,7 +11,7 @@ public class SimpleEnvironment implements Environment {
     public static final String PWD = "PWD";
     private final Map<String, String> vars;
 
-    SimpleEnvironment() {
+    public SimpleEnvironment() {
         vars = new HashMap<>();
         set("HOME", System.getProperty("user.home"));
         set("PWD", System.getProperty("user.dir"));

--- a/CLI/src/main/java/ru/spbau/sd/cli/interpreter/SimpleEnvironment.java
+++ b/CLI/src/main/java/ru/spbau/sd/cli/interpreter/SimpleEnvironment.java
@@ -7,7 +7,15 @@ import java.util.Map;
  * An implementation of the Environment interface based on a hash table.
  */
 public class SimpleEnvironment implements Environment {
-    private Map<String, String> vars = new HashMap<>();
+    public static final String HOME = "HOME";
+    public static final String PWD = "PWD";
+    private final Map<String, String> vars;
+
+    SimpleEnvironment() {
+        vars = new HashMap<>();
+        set("HOME", System.getProperty("user.home"));
+        set("PWD", System.getProperty("user.dir"));
+    }
 
     public void set(String name, String val) {
         vars.put(name, val);

--- a/CLI/src/main/java/ru/spbau/sd/cli/interpreter/commands/CmdCd.java
+++ b/CLI/src/main/java/ru/spbau/sd/cli/interpreter/commands/CmdCd.java
@@ -39,7 +39,10 @@ public class CmdCd implements Command {
                 outputStream.write("Please provide 0 or 1 argument");
                 return ExecutionResult.Error;
             }
-            File file = new File(environment.get(SimpleEnvironment.PWD) + File.separator + arguments.get(0));
+            File file = new File(arguments.get(0));
+            if (!file.isAbsolute()) {
+                file = new File(environment.get(SimpleEnvironment.PWD) + File.separator + arguments.get(0));
+            }
             if (!file.exists()) {
                 outputStream.write("cd: " + arguments.get(0) + ": No such file or directory");
                 return ExecutionResult.Error;

--- a/CLI/src/main/java/ru/spbau/sd/cli/interpreter/commands/CmdCd.java
+++ b/CLI/src/main/java/ru/spbau/sd/cli/interpreter/commands/CmdCd.java
@@ -1,0 +1,61 @@
+package ru.spbau.sd.cli.interpreter.commands;
+
+import ru.spbau.sd.cli.interpreter.Environment;
+import ru.spbau.sd.cli.interpreter.ExecutionResult;
+import ru.spbau.sd.cli.interpreter.SimpleEnvironment;
+import ru.spbau.sd.cli.interpreter.io.InputStream;
+import ru.spbau.sd.cli.interpreter.io.OutputStream;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * cd command
+ */
+public class CmdCd implements Command {
+    private final Environment environment;
+
+    public CmdCd(Environment environment) {
+        this.environment = environment;
+    }
+
+    /**
+     * Sets the current folder as the '/home' folder or as a folder extracted from the argument.
+     * @param arguments    command line arguments
+     * @param inputStream  input stream to read
+     * @param outputStream output stream to write results
+     * @return result type: OK if finished successfully, Error if > 1 arguments were provided
+     * or a folder at the argument path does not exist.
+     * Finish if the interpreter session should be closed.
+     */
+    @Override
+    public ExecutionResult run(List<String> arguments, InputStream inputStream, OutputStream outputStream) {
+        String folderAsString;
+        if (arguments.isEmpty()) {
+            folderAsString = System.getProperty("user.home");
+        } else {
+            if (arguments.size() != 1) {
+                outputStream.write("Please provide 0 or 1 argument");
+                return ExecutionResult.Error;
+            }
+            File file = new File(environment.get(SimpleEnvironment.PWD) + File.separator + arguments.get(0));
+            if (!file.exists()) {
+                outputStream.write("cd: " + arguments.get(0) + ": No such file or directory");
+                return ExecutionResult.Error;
+            }
+            if (!file.isDirectory()) {
+                outputStream.write("cd: " + arguments.get(0) + ": Not a directory");
+                return ExecutionResult.Error;
+            }
+            try {
+                folderAsString = file.getCanonicalPath();
+            } catch (IOException e) {
+                outputStream.write(e.getMessage());
+                return ExecutionResult.Error;
+            }
+        }
+        environment.set(SimpleEnvironment.PWD, folderAsString);
+        return ExecutionResult.OK;
+    }
+}

--- a/CLI/src/main/java/ru/spbau/sd/cli/interpreter/commands/CmdLs.java
+++ b/CLI/src/main/java/ru/spbau/sd/cli/interpreter/commands/CmdLs.java
@@ -51,12 +51,12 @@ public class CmdLs implements Command {
         }
         File[] folderContent = folder.listFiles(file -> !file.isHidden());
         if (folderContent == null) {
-            outputStream.write(folder + "\n");
+            outputStream.write(folder.getName() + "\n");
             return ExecutionResult.OK;
         }
         Arrays.sort(folderContent, Comparator.comparing(a -> a.getName().toLowerCase()));
         for (File folderElement: folderContent) {
-            outputStream.write(folderElement.getName());
+            outputStream.write(folderElement.getName() + "\n");
         }
         return ExecutionResult.OK;
     }

--- a/CLI/src/main/java/ru/spbau/sd/cli/interpreter/commands/CmdLs.java
+++ b/CLI/src/main/java/ru/spbau/sd/cli/interpreter/commands/CmdLs.java
@@ -1,0 +1,63 @@
+package ru.spbau.sd.cli.interpreter.commands;
+
+import ru.spbau.sd.cli.interpreter.Environment;
+import ru.spbau.sd.cli.interpreter.ExecutionResult;
+import ru.spbau.sd.cli.interpreter.SimpleEnvironment;
+import ru.spbau.sd.cli.interpreter.io.InputStream;
+import ru.spbau.sd.cli.interpreter.io.OutputStream;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * ls command
+ */
+public class CmdLs implements Command {
+    private final Environment environment;
+
+    public CmdLs(Environment environment) {
+        this.environment = environment;
+    }
+
+    /**
+     * Prints content (non-hidden files and folders) of the current folder
+     * or a folder at the argument path in alphabetical order.
+     * In case of file at the argument path, prints its name;
+     *
+     * @param arguments    command line arguments
+     * @param inputStream  input stream to read
+     * @param outputStream output stream to write results
+     * @return result type: OK if finished successfully, Error if > 1 arguments were provided
+     * or a file/folder at the argument path does not exist.
+     * Finish if the interpreter session should be closed.
+     */
+    @Override
+    public ExecutionResult run(List<String> arguments, InputStream inputStream, OutputStream outputStream) {
+        File folder;
+        if (arguments.isEmpty()) {
+            folder = new File(environment.get(SimpleEnvironment.PWD));
+        } else {
+            if (arguments.size() != 1) {
+                outputStream.write("Please provide 0 or 1 argument");
+                return ExecutionResult.Error;
+            }
+            folder = new File(arguments.get(0));
+        }
+        if (!folder.exists()) {
+            outputStream.write("ls: cannot access '" + folder + "': No such file or directory");
+            return ExecutionResult.OK;
+        }
+        File[] folderContent = folder.listFiles(file -> !file.isHidden());
+        if (folderContent == null) {
+            outputStream.write(folder + "\n");
+            return ExecutionResult.OK;
+        }
+        Arrays.sort(folderContent, Comparator.comparing(a -> a.getName().toLowerCase()));
+        for (File folderElement: folderContent) {
+            outputStream.write(folderElement.getName());
+        }
+        return ExecutionResult.OK;
+    }
+}

--- a/CLI/src/main/java/ru/spbau/sd/cli/interpreter/commands/CmdPwd.java
+++ b/CLI/src/main/java/ru/spbau/sd/cli/interpreter/commands/CmdPwd.java
@@ -1,6 +1,8 @@
 package ru.spbau.sd.cli.interpreter.commands;
 
+import ru.spbau.sd.cli.interpreter.Environment;
 import ru.spbau.sd.cli.interpreter.ExecutionResult;
+import ru.spbau.sd.cli.interpreter.SimpleEnvironment;
 import ru.spbau.sd.cli.interpreter.io.InputStream;
 import ru.spbau.sd.cli.interpreter.io.OutputStream;
 
@@ -12,11 +14,16 @@ import java.util.List;
  * Writes path to the current directory to the output stream.
  */
 public class CmdPwd implements Command {
+    private final Environment environment;
+
+    public CmdPwd(Environment environment) {
+        this.environment = environment;
+    }
+
     @Override
     public ExecutionResult run(List<String> arguments, InputStream inputStream,
                                OutputStream outputStream) {
-        Path curPath = Paths.get(".").normalize().toAbsolutePath();
-        outputStream.write(curPath.toString());
+        outputStream.write(environment.get(SimpleEnvironment.PWD));
         return ExecutionResult.OK;
     }
 }

--- a/CLI/src/test/java/ru/spbau/sd/cli/interpreter/commands/CmdCdTest.java
+++ b/CLI/src/test/java/ru/spbau/sd/cli/interpreter/commands/CmdCdTest.java
@@ -1,0 +1,48 @@
+package ru.spbau.sd.cli.interpreter.commands;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+import ru.spbau.sd.cli.interpreter.Environment;
+import ru.spbau.sd.cli.interpreter.SimpleEnvironment;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+
+public class CmdCdTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void runTest() throws IOException {
+        Environment environment = new SimpleEnvironment();
+        File sub = folder.newFolder("sub");
+        File file = folder.newFile("file");
+        Command cdCommand = new CmdCd(environment);
+        ru.spbau.sd.cli.interpreter.io.OutputStream outputStream =
+                Mockito.mock(ru.spbau.sd.cli.interpreter.io.OutputStream.class);
+        cdCommand.run(Collections.singletonList(file.getAbsolutePath()), null, outputStream);
+        Mockito.verify(outputStream).write("cd: " + file.getAbsolutePath() + ": Not a directory");
+
+        outputStream = Mockito.mock(ru.spbau.sd.cli.interpreter.io.OutputStream.class);
+        cdCommand.run(Collections.singletonList(file.getAbsolutePath() + "?"), null, outputStream);
+        Mockito.verify(outputStream).write("cd: " + file.getAbsolutePath() + "?: No such file or directory");
+
+        cdCommand.run(Collections.singletonList(folder.getRoot().getAbsolutePath()), null, outputStream);
+        cdCommand.run(Collections.singletonList("sub"), null, outputStream);
+        Command pwdCommand = new CmdPwd(environment);
+        outputStream = Mockito.mock(ru.spbau.sd.cli.interpreter.io.OutputStream.class);
+        pwdCommand.run(Collections.emptyList(), null, outputStream);
+        Mockito.verify(outputStream).write(sub.getAbsolutePath());
+        outputStream = Mockito.mock(ru.spbau.sd.cli.interpreter.io.OutputStream.class);
+        cdCommand.run(Collections.singletonList("."), null, outputStream);
+        pwdCommand.run(Collections.emptyList(), null, outputStream);
+        Mockito.verify(outputStream).write(sub.getAbsolutePath());
+        outputStream = Mockito.mock(ru.spbau.sd.cli.interpreter.io.OutputStream.class);
+        cdCommand.run(Collections.singletonList(".."), null, outputStream);
+        pwdCommand.run(Collections.emptyList(), null, outputStream);
+        Mockito.verify(outputStream).write(folder.getRoot().getAbsolutePath());
+    }
+}

--- a/CLI/src/test/java/ru/spbau/sd/cli/interpreter/commands/CmdLsTest.java
+++ b/CLI/src/test/java/ru/spbau/sd/cli/interpreter/commands/CmdLsTest.java
@@ -1,0 +1,47 @@
+package ru.spbau.sd.cli.interpreter.commands;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+import ru.spbau.sd.cli.interpreter.SimpleEnvironment;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+
+public class CmdLsTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void runTest() throws IOException {
+        File subfolder = folder.newFolder("subfolder");
+        File file = folder.newFile("file");
+        Command lsCommand = new CmdLs(new SimpleEnvironment());
+        ru.spbau.sd.cli.interpreter.io.OutputStream outputStream =
+                Mockito.mock(ru.spbau.sd.cli.interpreter.io.OutputStream.class);
+        lsCommand.run(Collections.singletonList(folder.getRoot().getAbsolutePath()),
+                null, outputStream);
+        Mockito.verify(outputStream).write(Mockito.eq("file\n"));
+        Mockito.verify(outputStream).write(Mockito.eq("subfolder\n"));
+
+        outputStream = Mockito.mock(ru.spbau.sd.cli.interpreter.io.OutputStream.class);
+        lsCommand.run(Collections.singletonList("abracadabra"), null, outputStream);
+        Mockito.verify(outputStream).write(Mockito.eq("ls: cannot access 'abracadabra': No such file or directory"));
+
+        outputStream = Mockito.mock(ru.spbau.sd.cli.interpreter.io.OutputStream.class);
+        lsCommand.run(Collections.singletonList(file.getAbsolutePath()), null, outputStream);
+        Mockito.verify(outputStream).write(Mockito.eq("file\n"));
+
+        outputStream = Mockito.mock(ru.spbau.sd.cli.interpreter.io.OutputStream.class);
+        lsCommand.run(Collections.singletonList(subfolder.getAbsolutePath()), null, outputStream);
+        Mockito.verifyZeroInteractions(outputStream);
+    }
+}

--- a/CLI/src/test/java/ru/spbau/sd/cli/interpreter/commands/CmdPwdTest.java
+++ b/CLI/src/test/java/ru/spbau/sd/cli/interpreter/commands/CmdPwdTest.java
@@ -2,6 +2,7 @@ package ru.spbau.sd.cli.interpreter.commands;
 
 import org.junit.Test;
 import org.mockito.Mockito;
+import ru.spbau.sd.cli.interpreter.SimpleEnvironment;
 
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -9,11 +10,12 @@ import java.util.Collections;
 public class CmdPwdTest {
     @Test
     public void runTest() {
-        Command pwdCommand = new CmdPwd();
+        Command pwdCommand = new CmdPwd(new SimpleEnvironment());
         String dir = Paths.get(".").toAbsolutePath().normalize().toString();
         ru.spbau.sd.cli.interpreter.io.OutputStream outputStream =
                 Mockito.mock(ru.spbau.sd.cli.interpreter.io.OutputStream.class);
         pwdCommand.run(Collections.emptyList(), null, outputStream);
         Mockito.verify(outputStream).write(dir);
+
     }
 }


### PR DESCRIPTION
Пришлось создать два класса (CmdLs и CmdCd), в которых реализовал логику, и добавить соответствующие создания команд в парсере.
Добавил в Environment две переменных - HOME и PWD.
Подправил CmdPwd, т.к. она всегда выводила стартовую папку (выполнение cd не влияло на него).
Больше ничего не пришлось менять, очень просто вышло.